### PR TITLE
解决在 https 限制的网站无法播放音频

### DIFF
--- a/src/assets/dict.js
+++ b/src/assets/dict.js
@@ -256,6 +256,7 @@
             this.domResult.find('.icIBahyI-eg a').each(function( index, a ){
                 a = $( a );
                 var mp3 = /(http\:.*\.mp3)/.exec(a.attr( 'onclick' ))[0];
+                mp3 = mp3.replace('http:', 'https:');
                 a.attr( 'data-audio-url', mp3 );
                 a.removeAttr( 'onclick' );
                 a.addClass( 'fa fa-volume-up iciba-extension-pronounce' );


### PR DESCRIPTION
在有 https 限制的网站如 github, medium 等，无法播放音频。把音频地址替换为 https 即可。